### PR TITLE
Stack LTS 10.10

### DIFF
--- a/ec2-unikernel.cabal
+++ b/ec2-unikernel.cabal
@@ -30,11 +30,11 @@ executable ec2-unikernel
                        directory      >= 1.2.2 && < 1.4,
                        filepath       >= 1.3.0 && < 1.5,
                        lens           >= 4.13  && < 5.0,
-                       process        >= 1.2   && < 1.5,
+                       process        >= 1.2   && < 1.7,
                        semigroups     >= 0.18  && < 0.20,
                        temporary      >= 1.2.0 && < 1.4,
                        text           >= 1.2.2 && < 1.4,
-                       time           >= 1.5   && < 1.8,
+                       time           >= 1.5   && < 1.9,
                        unix           >= 2.7.1 && < 2.9
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-10.10


### PR DESCRIPTION
I was unable to build this project on Debian/Ubuntu with cabal-install pulling from hackage (0.9.2). There is a compilation error with Amazonka 1.4.x

I was unable to build this project on Debian/Ubuntu with cabal-install pulling from git master (0.9.7) there was a GHC 8.0.1 panic at the end.

I was unable to build this project on Debian/Ubuntu with stack pulling from hackage (0.9.2) on LTS-9. There is a compilation error with Amazonka 1.4.x

I was unable to build this project on Debian/Ubuntu with stack pulling from git master (0.9.7) on LTS-10. The packages would not resolve. This project depends on older process and time packages.

I **was** able to build this project on Debian/Ubuntu with stack pulling from git master (0.9.7) on LTS-10 after I loosened up **process** and **time** cabal constraints. The application compiles and seems to function fine. I have provided a small stack.yaml file so people with stack can install easily. Cabal install should still work fine and dandy also.

73s!
